### PR TITLE
fix: fix collision bug(s)

### DIFF
--- a/playscii/playscii.py
+++ b/playscii/playscii.py
@@ -142,7 +142,7 @@ class GameObject(ABC):
     def on_collision(self, other: 'GameObject') -> bool:
         "Returns True if the GameObject has collided with another GameObject."
         return (
-            other.x - other.width <= self.x
+            other.x <= self.x
             <= other.x + other.width
         ) and (
             other.y - other.height <= self.y

--- a/playscii/playscii.py
+++ b/playscii/playscii.py
@@ -144,7 +144,7 @@ class GameObject(ABC):
             return (
                 (other.x <= self.x <= other.x + other.width) or (self.x <= other.x <= self.x + self.width)
                 ) and (
-                (other.y - other.height <= self.y <= other.y) or (other.y - other.height <= self.y <= other.y))
-
+                (other.y - other.height <= self.y <= other.y) or (self.y - self.height <= other.y <= self.y))
+        
     def update(self):
         pass

--- a/playscii/playscii.py
+++ b/playscii/playscii.py
@@ -140,14 +140,11 @@ class GameObject(ABC):
                 board[~(y - i)][x + j] = render_text[i][j]
 
     def on_collision(self, other: 'GameObject') -> bool:
-        "Returns True if the GameObject has collided with another GameObject."
-        return (
-            other.x <= self.x
-            <= other.x + other.width
-        ) and (
-            other.y - other.height <= self.y
-            <= other.y + other.height
-        )
+            "Returns True if the GameObject has collided with another GameObject."
+            return (
+                (other.x <= self.x <= other.x + other.width) or (self.x <= other.x <= self.x + self.width)
+                ) and (
+                (other.y - other.height <= self.y <= other.y) or (other.y - other.height <= self.y <= other.y))
 
     def update(self):
         pass


### PR DESCRIPTION
Currently, hitboxes extend `width` away from the center (`x`) of the `other` object in both directions. The sprites only extend from `x` to the right, meaning there's an invisible hitbox to the left of the sprite. The same applies vertically.

This removes the invisible hitbox. It checks if the center of either object intersects with the center to width/height of the other object.